### PR TITLE
Ensure resumen chart refreshes after data changes

### DIFF
--- a/app.bundle.js
+++ b/app.bundle.js
@@ -95,7 +95,14 @@ $('#tab-gastos').onclick=()=>setTab('gastos'); $('#tab-resumen').onclick=()=>set
 
 function renderMonedas(){ ['#g-moneda','#f-moneda','#r-moneda','#c-moneda'].forEach(sel=>{ const el=$(sel); el.innerHTML=''; MONEDAS.forEach(m=>{ const o=document.createElement('option'); o.value=m; o.textContent=m; el.appendChild(o); }); }); }
 
-async function loadAll(){ state.cuentas=await getCuentas(); state.categorias=await getCategorias(); state.gastos=await getGastos(); renderAll(); }
+async function loadAll(){
+  state.cuentas=await getCuentas();
+  state.categorias=await getCategorias();
+  state.gastos=await getGastos();
+  renderAll();
+  const tabResumen=document.querySelector('#tab-resumen');
+  if(tabResumen && tabResumen.classList.contains('active')) renderResumen();
+}
 
 function renderAll(){
   renderMonedas(); if($('#g-fecha').value==='') $('#g-fecha').valueAsDate=new Date();


### PR DESCRIPTION
## Summary
- update loadAll to rerender the resumen view whenever the resumen tab is active after data reloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca7558f32c832f9343c9c73785b1ac